### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/omsApp/src/drvMAXv.cc
+++ b/omsApp/src/drvMAXv.cc
@@ -191,14 +191,14 @@ static long report(int);
 static long init();
 static void query_done(int, int, struct mess_node *);
 static int set_status(int, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int recv_mess(int, char *, int);
 static int getPositions(int card, epicsInt32 *positions, int nPositions);
-static int send_recv_mess(int card, char const * command, char *axis, char *buf, int nMessages);
+static int send_recv_mess(int card, const char * command, const char *axis, char *buf, int nMessages);
 
 extern "C" {
 
-int MAXV_send_mess(int card, char const * command, char *axis) {
+int MAXV_send_mess(int card, const char * command, const char *axis) {
     return (int)send_mess(card, command, axis);
 }
 
@@ -206,7 +206,7 @@ int MAXV_recv_mess(int card, char *buf, int nMessages) {
     return recv_mess(card, buf, nMessages);
 }
 
-int MAXV_send_recv_mess(int card, char const * command, char *axis, char *buf, int nMessages) {
+int MAXV_send_recv_mess(int card, const char * command, const char *axis, char *buf, int nMessages) {
     return send_recv_mess(card, command, axis, buf, nMessages);
 }
 
@@ -255,7 +255,7 @@ struct driver_table MAXv_access =
     query_done,
     NULL,
     &initialized,
-    (char **) MAXv_axis
+    MAXv_axis
 };
 
 struct drvMAXv_drvet
@@ -396,7 +396,7 @@ static int set_status(int card, int signal)
             errlogPrintf(wdctrmsg, card, q_buf);
             status.Bits.RA_PROBLEM = 1;
             motor_info->status.All = status.All;
-            send_mess(card, STOP_ALL, (char*) NULL);
+            send_mess(card, STOP_ALL, NULL);
             /* Disable board. */
             motor_state[card] = (struct controller *) NULL;
             return(rtn_state = 1); /* End move. */
@@ -406,14 +406,14 @@ static int set_status(int card, int signal)
     if (motor_info->encoder_present == YES)
     {
         /* get 4 pieces of info from axis */
-        send_recv_mess(card, "QA", (char *) MAXv_axis[signal], &q_buf[0], 1);
+        send_recv_mess(card, "QA", MAXv_axis[signal], &q_buf[0], 1);
         q_buf[4] = ',';
-        send_recv_mess(card, "EA", (char *) MAXv_axis[signal], &q_buf[5], 1);
+        send_recv_mess(card, "EA", MAXv_axis[signal], &q_buf[5], 1);
     }
     else
     {
         /* get 2 pieces of info from axis */
-        send_recv_mess(card, AXIS_INFO, (char *) MAXv_axis[signal], q_buf, 1);
+        send_recv_mess(card, AXIS_INFO, MAXv_axis[signal], q_buf, 1);
     }
 
     for (index = 0, p = epicsStrtok_r(q_buf, ",", &tok_save); p;
@@ -489,7 +489,7 @@ static int set_status(int card, int signal)
         status.Bits.RA_PROBLEM = 0;
 
     /* get command velocity */
-    send_recv_mess(card, "RV", (char *) MAXv_axis[signal], q_buf, 1);
+    send_recv_mess(card, "RV", MAXv_axis[signal], q_buf, 1);
     motor_info->velocity = atoi(q_buf);
 
     /* Get encoder position */
@@ -606,7 +606,7 @@ errorexit:      errMessage(-1, "Invalid device directive");
 /**************************************************
  * send a message to the OMS board and get the reply
  **************************************************/
-static int send_recv_mess(int card, char const * command, char *axis, char *buf, int nMessages) {
+static int send_recv_mess(int card, const char * command, const char *axis, char *buf, int nMessages) {
     int retval;
 
     if (!epicsMutexTryLock(MUTEX(card))) {
@@ -623,7 +623,7 @@ static int send_recv_mess(int card, char const * command, char *axis, char *buf,
 /* send a message to the OMS board                   */
 /* send_mess()                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     volatile struct MAXv_motor *pmotor;
     epicsInt16 putIndex;
@@ -1261,10 +1261,11 @@ static int motor_init()
         pmotor->status1_irq_enable.All = 0;
         pmotor->status2_irq_enable = 0;
 
-        send_mess(card_index, ERROR_CLEAR, (char*) NULL);
-        send_mess(card_index, STOP_ALL, (char*) NULL);
+        send_mess(card_index, ERROR_CLEAR, NULL);
+        send_mess(card_index, STOP_ALL, NULL);
 
-        rtn_code = send_recv_mess(card_index, GET_IDENT, (char* ) NULL, (char *) pmotorState->ident, 1);
+        rtn_code = send_recv_mess(card_index, GET_IDENT, NULL, (char *) pmotorState->ident, 1);
+
         if (rtn_code != 0)
         {
             errlogPrintf("\n***MAXv card #%d Disabled*** not responding to commands!\n\n", card_index);
@@ -1293,7 +1294,7 @@ static int motor_init()
 
         if (wdtrip == false)
         {
-            send_mess(card_index, initstring[card_index], (char*) NULL);
+            send_mess(card_index, initstring[card_index], NULL);
 
             send_recv_mess(card_index, ALL_POS, (char *) NULL, axis_pos, 1);
 
@@ -1313,7 +1314,7 @@ static int motor_init()
                 STATUS1 flag1;
 
                 /* Test if motor has an encoder. */
-                send_mess(card_index, ENCODER_QUERY, (char *) MAXv_axis[motor_index]);
+                send_mess(card_index, ENCODER_QUERY, MAXv_axis[motor_index]);
                 while (!pmotor->status1_flag.Bits.done) /* Wait for command to complete. */
                     epicsThreadSleep(quantum);
 
@@ -1332,7 +1333,7 @@ static int motor_init()
                 }
                 
                 /* Test if motor has PID parameters. */
-                send_mess(card_index, PID_QUERY, (char *) MAXv_axis[motor_index]);
+                send_mess(card_index, PID_QUERY, MAXv_axis[motor_index]);
                 while (!pmotor->status1_flag.Bits.done) /* Wait for command to complete. */
                     epicsThreadSleep(quantum);
                 if (pmotor->status1_flag.Bits.cmndError)
@@ -1359,9 +1360,9 @@ static int motor_init()
 
                 if (pvtdata->fwver >= 1.30)
                 {
-                    send_recv_mess(card_index, "LM?", (char *) MAXv_axis[motor_index], axis_pos, 1);
+                    send_recv_mess(card_index, "LM?", MAXv_axis[motor_index], axis_pos, 1);
                     if (strcmp(axis_pos, "=f") == 0) /* If limit mode is set to "Off". */
-                        send_mess(card_index, "LMH", (char *) MAXv_axis[motor_index]); /* Set limit mode to "Hard". */
+                        send_mess(card_index, "LMH", MAXv_axis[motor_index]); /* Set limit mode to "Hard". */
                 }
             }
 
@@ -1388,7 +1389,7 @@ static int motor_init()
 
                 set_status(card_index, motor_index);
                 /* Is this needed??? */
-                send_recv_mess(card_index, DONE_QUERY, (char *) MAXv_axis[motor_index], axis_pos, 1);
+                send_recv_mess(card_index, DONE_QUERY, MAXv_axis[motor_index], axis_pos, 1);
             }
 
             Debug(2, "motor_init: Init Address=%p\n", localaddr);

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -153,7 +153,7 @@ static char *oms_addrs = 0x0;
 static volatile unsigned omsInterruptVector = 0;
 static volatile epicsUInt8 omsInterruptLevel = OMS_INT_LEVEL;
 static volatile int motionTO = 10;
-static char *oms_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
+static const char *oms_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
 static double quantum;
 
 /*----------------functions-----------------*/
@@ -163,7 +163,7 @@ static long report(int);
 static long init();
 static void query_done(int, int, struct mess_node *);
 static int set_status(int, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int recv_mess(int, char *, int);
 static void motorIsr(int);
 static int motor_init();
@@ -209,7 +209,7 @@ struct drvOms_drvet
 extern "C" {epicsExportAddress(drvet, drvOms);}
 
 static struct thread_args targs = {SCAN_RATE, &oms_access, 0.010};
-static char rebootmsg[] = "\n\n*** OMS card #%d Disabled *** Reboot Detected.\n\n";
+static const char rebootmsg[] = "\n\n*** OMS card #%d Disabled *** Reboot Detected.\n\n";
 
 /*----------------functions-----------------*/
 
@@ -456,7 +456,7 @@ errorexit:      errMessage(-1, "Invalid device directive");
 /* send a message to the OMS board                   */
 /*              send_mess()                          */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char outbuf[MAX_MSG_SIZE];
     RTN_STATUS return_code;

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -187,7 +187,7 @@ static volatile unsigned omsInterruptVector = 0;
 static volatile epicsUInt8 omsInterruptLevel = OMS_INT_LEVEL;
 static volatile int max_io_tries = MAX_COUNT;
 static volatile int motionTO = 10;
-static char *oms58_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
+static const char *oms58_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
 static double quantum;
 
 /*----------------functions-----------------*/
@@ -197,7 +197,7 @@ static long report(int);
 static long init();
 static void query_done(int, int, struct mess_node *);
 static int set_status(int, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int recv_mess(int, char *, int);
 static void motorIsr(int card);
 static int motor_init();
@@ -239,7 +239,7 @@ struct drvOms58_drvet
 
 extern "C" {epicsExportAddress(drvet, drvOms58);}
 
-static char rebootmsg[] = "\n\n*** VME58 card #%d Disabled *** Reboot Detected.\n\n";
+static const char rebootmsg[] = "\n\n*** VME58 card #%d Disabled *** Reboot Detected.\n\n";
 
 static struct thread_args targs = {SCAN_RATE, &oms58_access, 0.000};
 
@@ -660,7 +660,7 @@ errorexit:      errMessage(-1, "Invalid device directive");
 /* send a message to the OMS board		     */
 /* send_mess()			     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     volatile struct vmex_motor *pmotor;
     epicsInt16 putIndex;

--- a/omsApp/src/drvOmsPC68.cc
+++ b/omsApp/src/drvOmsPC68.cc
@@ -107,12 +107,12 @@ int OmsPC68_num_cards = 0;
 static volatile int motionTO = 10;
 
 //OmsPC68 generic controller commands
-static char *oms_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
+static const char *oms_axis[] = {"X", "Y", "Z", "T", "U", "V", "R", "S"};
 
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *name);
+static RTN_STATUS send_mess(int, const char *, const char *name);
 static void start_status(int card);
 static int set_status(int card, int signal);
 static long report(int level);
@@ -454,7 +454,7 @@ exit:
 /* send a message to the OmsPC68 board               */
 /* send_mess()                                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct OmsPC68controller    *cntrl;
     size_t              size,
@@ -770,7 +770,7 @@ static int motor_init()
             /* Try 3 times to connect to controller. */
             do
             {
-                send_mess (card_index, GET_IDENT, (char*) NULL);
+                send_mess (card_index, GET_IDENT, NULL);
                 status = recv_mess(card_index, (char *) pmotorState->ident, 1);
                 retry++;
             } while (status == 0 && retry < 3);
@@ -783,11 +783,11 @@ static int motor_init()
             pmotorState->motor_in_motion = 0;
             pmotorState->cmnd_response = false;
 
-            send_mess (card_index, ECHO_OFF, (char*) NULL);
-            send_mess (card_index, ERROR_CLEAR, (char*) NULL);
-            send_mess (card_index, STOP_ALL, (char*) NULL);
+            send_mess (card_index, ECHO_OFF, NULL);
+            send_mess (card_index, ERROR_CLEAR, NULL);
+            send_mess (card_index, STOP_ALL, NULL);
 
-            send_mess (card_index, ALL_POS, (char*) NULL);
+            send_mess (card_index, ALL_POS, NULL);
             recv_mess (card_index, axis_pos, 1);
 
             for (total_axis = 0, pos_ptr = epicsStrtok_r(axis_pos, ",", &tok_save);
@@ -822,7 +822,7 @@ static int motor_init()
              * dummy communication transaction.
              */
 
-            send_mess (card_index, ALL_POS, (char*) NULL);
+            send_mess (card_index, ALL_POS, NULL);
             recv_mess (card_index, axis_pos, 1);
 
             for (motor_index=0;motor_index<total_axis;motor_index++)


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.