### PR TITLE
Fix cast from void* to epicsUInt32 loses precision

### DIFF
--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -1032,11 +1032,7 @@ omsSetup(int num_cards,  /* maximum number of cards in rack */
         oms44_num_cards = num_cards;
 
     /* Check boundary(16byte) on base address */
-#ifdef __LP64__
-    if ((motorUInt64) addrs & 0xF)
-#else
-    if ((epicsUInt32) addrs & 0xF)
-#endif
+    if ((epicsUInt64) addrs & 0xF)
     {
     }
     else

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -941,11 +941,7 @@ oms58Setup(int num_cards,   /* maximum number of cards in rack */
         oms58_num_cards = num_cards;
 
     /* Check range and boundary(4K) on base address */
-#ifdef __LP64__
-    if (addrs > (void *) 0xF000 || ((motorUInt64) addrs & 0xFFF))
-#else
-    if (addrs > (void *) 0xF000 || ((epicsUInt32) addrs & 0xFFF))
-#endif
+    if (addrs > (void *) 0xF000 || ((epicsUInt64)addrs & 0xFFF))
     {
         char format[] = "%sbase address = %p ***\n";
         oms_addrs = (char *) OMS_NUM_ADDRS;

--- a/omsApp/src/drvOmsCom.h
+++ b/omsApp/src/drvOmsCom.h
@@ -39,8 +39,11 @@ USAGE... 	This file contains OMS driver "include" information
 
 #include "motordrvCom.h"
 
-#ifdef __LP64__
-typedef long long motorUInt64;
+#if LT_EPICSBASE(3,15,0,2)
+  #if __STDC_VERSION__ < 199901L
+    typedef long long          epicsInt64;
+    typedef unsigned long long epicsUInt64;
+  #endif
 #endif
 
 /* Default profile. */


### PR DESCRIPTION
Fix the compiler error on Windows64:
cast from ‘void*’ to ‘epicsUInt32 {aka unsigned int}’ loses precision

Introduce epicsUInt64 in the same way that asyn does it and use it
to look at the low-bits of address-pointers.