### PR TITLE
Enable non vx works iocs

### DIFF
--- a/omsApp/src/MAX_trajectoryScan.st
+++ b/omsApp/src/MAX_trajectoryScan.st
@@ -862,7 +862,7 @@ static int writeOnly(SS_ID ssId, struct UserVar *pVar, char *command)
 	}
 #else
 	if (pVar->simMode==0) {
-		status = (asynStatus) MAXV_send_mess(pVar->cardNumber, command, (char *) NULL);
+		status = (asynStatus) MAXV_send_mess(pVar->cardNumber, command, NULL);
 	}
 #endif
 	if (pVar->execState==EXECUTE_STATE_EXECUTING)
@@ -896,10 +896,10 @@ static int writeRead(SS_ID ssId, struct UserVar *pVar, char *command, char *repl
 							   30.0, &nwrite, &nread, &eomReason);
 #else
 
-	/* status = (asynStatus) MAXV_send_mess(pVar->cardNumber, command, (char *) NULL);
+	/* status = (asynStatus) MAXV_send_mess(pVar->cardNumber, command, NULL);
 	 * status |= (asynStatus) MAXV_recv_mess(pVar->cardNumber, reply, 1);
 	 */
-	status = MAXV_send_recv_mess(pVar->cardNumber, command, (char *) NULL, reply, 1);
+	status = MAXV_send_recv_mess(pVar->cardNumber, command, NULL, reply, 1);
 #endif
 	if (pVar->debugLevel >= 2) {
 		printf("    writeRead:command='%s', reply='%s'\n", buffer, reply);

--- a/omsApp/src/devOmsCom.cc
+++ b/omsApp/src/devOmsCom.cc
@@ -257,7 +257,7 @@ RTN_STATUS oms_build_trans(motor_cmnd command, double *parms, struct motorRecord
                 struct driver_table *tabptr = trans->tabptr;
                 int size = (end - &mr->init[0]) + 1;
                 strncpy(buffer, mr->init, size);
-                buffer[size] = (char) NULL;
+                buffer[size] = 0;
                 if (strcmp(buffer, "@DPM_ON@") == 0)
                 {
                     int response, bitselect;
@@ -357,7 +357,7 @@ RTN_STATUS oms_build_trans(motor_cmnd command, double *parms, struct motorRecord
 
                             /* Copy device directive to prem_buff. */
                             strncpy(prem_buff, mr->prem, size);
-                            prem_buff[size] = (char) NULL;
+                            prem_buff[size] = 0;
 
                             if (strncmp(prem_buff, "@PUT(", 5) != 0)
                                 goto errorexit;

--- a/omsApp/src/devOmsCom.cc
+++ b/omsApp/src/devOmsCom.cc
@@ -264,7 +264,7 @@ RTN_STATUS oms_build_trans(motor_cmnd command, double *parms, struct motorRecord
                     char respbuf[10];
 
                     (*tabptr->getmsg)(card, respbuf, -1);
-                    (*tabptr->sendmsg)(card, "RB\r", (char*) NULL);
+                    (*tabptr->sendmsg)(card, "RB\r", NULL);
                     (*tabptr->getmsg)(card, respbuf, 1);
                     if (sscanf(respbuf, "%x", &response) == 0)
                         response = 0;   /* Force an error. */

--- a/omsApp/src/drvMAXv.cc
+++ b/omsApp/src/drvMAXv.cc
@@ -1111,7 +1111,7 @@ static int motorIsrSetup(int card)
 #else
         (void (*)(void *)) motorIsr,
 #endif
-        (void *) card);
+        (void *)(size_t) card);
 
     if (!RTN_SUCCESS(status))
     {

--- a/omsApp/src/drvMAXv.cc
+++ b/omsApp/src/drvMAXv.cc
@@ -542,7 +542,7 @@ static int set_status(int card, int signal)
 
                 /* Copy device directive to buffer. */
                 strncpy(buffer, nodeptr->postmsgptr, size);
-                buffer[size] = (char) NULL;
+                buffer[size] = 0;
 
                 if (strncmp(buffer, "@PUT(", 5) != 0)
                     goto errorexit;
@@ -774,7 +774,7 @@ static int recv_mess(int card, char *com, int amount)
     }
 
     bufptr = com;
-    *bufptr = (char) NULL;
+    *bufptr = 0;
 
     do
     {
@@ -861,7 +861,7 @@ static char *readbuf(volatile struct MAXv_motor *pmotor, char *bufptr)
         getIndex -= BUFFER_SIZE;
     
     bufptr += (bufsize - 1);
-    *bufptr = (char) NULL;
+    *bufptr = 0;
 
     while (getIndex != pmotor->inPutIndex)
     {
@@ -1016,7 +1016,7 @@ MAXvSetup(int num_cards,        /* maximum number of cards in rack */
     for (itera = 0, strptr = &initstring[0]; itera < MAXv_num_cards; itera++, strptr++)
     {
         *strptr = (char *) malloc(INITSTR_SIZE);
-        **strptr = (char) NULL;
+        **strptr = 0;
     }
 
     return(rtncode);

--- a/omsApp/src/drvMAXv.cc
+++ b/omsApp/src/drvMAXv.cc
@@ -304,10 +304,10 @@ static void query_done(int card, int axis, struct mess_node *nodeptr)
 {
     char buffer[MAX_IDENT_LEN];
 
-    send_recv_mess(card, DONE_QUERY, (char *) MAXv_axis[axis], buffer, 1);
+    send_recv_mess(card, DONE_QUERY, MAXv_axis[axis], buffer, 1);
 
     if (nodeptr->status.Bits.RA_PROBLEM)
-        send_mess(card, AXIS_STOP, (char *) MAXv_axis[axis]);
+        send_mess(card, AXIS_STOP, MAXv_axis[axis]);
 }
 
 
@@ -470,7 +470,7 @@ static int set_status(int card, int signal)
     if (motor_info->no_motion_count > motionTO)
     {
         status.Bits.RA_PROBLEM = 1;
-        send_mess(card, AXIS_STOP, (char *) MAXv_axis[signal]);
+        send_mess(card, AXIS_STOP, MAXv_axis[signal]);
         motor_info->no_motion_count = 0;
         errlogSevPrintf(errlogMinor, "Motor motion timeout ERROR on card: %d, signal: %d\n",
             card, signal);
@@ -577,7 +577,7 @@ errorexit:      errMessage(-1, "Invalid device directive");
             strcpy(buffer, nodeptr->postmsgptr);
 
         strcpy(outbuf, buffer);
-        send_mess(card, outbuf, (char *) MAXv_axis[signal]);
+        send_mess(card, outbuf, MAXv_axis[signal]);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -1394,7 +1394,7 @@ loopend:;
 
     Debug(3, "Motors initialized\n");
 
-    epicsThreadCreate((char *) "MAXv_motor", epicsThreadPriorityMedium,
+    epicsThreadCreate("MAXv_motor", epicsThreadPriorityMedium,
                       epicsThreadGetStackSize(epicsThreadStackMedium),
                       (EPICSTHREADFUNC) motor_task, (void *) &targs);
 

--- a/omsApp/src/drvMAXv.cc
+++ b/omsApp/src/drvMAXv.cc
@@ -385,7 +385,7 @@ static int set_status(int card, int signal)
     MAXvCntrl = (struct MAXvController *) brdptr->DevicePrivate;
     if (MAXvCntrl->fwver >= 1.33)
     {
-        send_recv_mess(card, "#WS", (char *) NULL, q_buf, 1);
+        send_recv_mess(card, "#WS", NULL, q_buf, 1);
         if (strcmp(q_buf, "=0") != 0)
         {
             errlogPrintf(wdctrmsg, card, q_buf);
@@ -393,7 +393,7 @@ static int set_status(int card, int signal)
             motor_info->status.All = status.All;
             send_mess(card, STOP_ALL, NULL);
             /* Disable board. */
-            motor_state[card] = (struct controller *) NULL;
+            motor_state[card] = NULL;
             return(rtn_state = 1); /* End move. */
         }
     }
@@ -1198,7 +1198,7 @@ static int motor_init()
         if (!PROBE_SUCCESS(status))
         {
             Debug(3, "motor_init: Card NOT found!\n");
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
             goto loopend;
         }
 
@@ -1210,7 +1210,7 @@ static int motor_init()
         {
             errPrintf(status, __FILE__, __LINE__, "Can't register address %#x\n",
                       probeAddr);
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
             goto loopend;
         }
 
@@ -1220,7 +1220,7 @@ static int motor_init()
         if (pmotor->firmware_status.Bits.running == 0)
         {
             errlogPrintf(norunmsg, card_index, (unsigned int) pmotor->firmware_status.All);
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
             goto loopend;
         }
 
@@ -1254,7 +1254,7 @@ static int motor_init()
         if (rtn_code != 0)
         {
             errlogPrintf("\n***MAXv card #%d Disabled*** not responding to commands!\n\n", card_index);
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
             goto loopend;
         }
         Debug(3, "Identification = %s\n", pmotorState->ident);
@@ -1267,12 +1267,12 @@ static int motor_init()
 
         if (pvtdata->fwver >= 1.33)
         {
-            send_recv_mess(card_index, "#WS", (char *) NULL, axis_pos, 1);
+            send_recv_mess(card_index, "#WS", NULL, axis_pos, 1);
             if (strcmp(axis_pos, "=0") != 0)
             {
                 errlogPrintf(wdctrmsg, card_index, axis_pos);
                 epicsThreadSleep(2.0);
-                motor_state[card_index] = (struct controller *) NULL;
+                motor_state[card_index] = NULL;
                 wdtrip = true;
             }
         }
@@ -1281,7 +1281,7 @@ static int motor_init()
         {
             send_mess(card_index, initstring[card_index], NULL);
 
-            send_recv_mess(card_index, ALL_POS, (char *) NULL, axis_pos, 1);
+            send_recv_mess(card_index, ALL_POS, NULL, axis_pos, 1);
 
             for (total_axis = 0, pos_ptr = epicsStrtok_r(axis_pos, ",", &tok_save);
                  pos_ptr; pos_ptr = epicsStrtok_r(NULL, ",", &tok_save), total_axis++)
@@ -1386,11 +1386,11 @@ loopend:;
 
     any_motor_in_motion = 0;
 
-    mess_queue.head = (struct mess_node *) NULL;
-    mess_queue.tail = (struct mess_node *) NULL;
+    mess_queue.head = NULL;
+    mess_queue.tail = NULL;
 
-    free_list.head = (struct mess_node *) NULL;
-    free_list.tail = (struct mess_node *) NULL;
+    free_list.head = NULL;
+    free_list.tail = NULL;
 
     Debug(3, "Motors initialized\n");
 

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -408,7 +408,7 @@ static int set_status(int card, int signal)
 
                 /* Copy device directive to buffer. */
                 strncpy(buffer, nodeptr->postmsgptr, size);
-                buffer[size] = (char) NULL;
+                buffer[size] = 0;
 
                 if (strncmp(buffer, "@PUT(", 5) != 0)
                     goto errorexit;

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -917,7 +917,6 @@ static int motorIsrEnable(int card)
     irqdata = (struct irqdatastr *) pmotorState->DevicePrivate;
     pmotor = (struct vmex_motor *) (pmotorState->localaddr);
 
-#ifdef vxWorks
     {
         long status;
         status = pdevLibVirtualOS->pDevConnectInterruptVME(
@@ -951,7 +950,6 @@ static int motorIsrEnable(int card)
             return(ERROR);
         }
     }
-#endif
 
     /* Setup card for interrupt-on-done */
     pmotor->vector = omsInterruptVector + card;
@@ -988,9 +986,7 @@ static void motorIsrDisable(int card)
     /* Disable interrupts */
     pmotor->control = IRQ_RESET_ID;
 
-#ifdef vxWorks
     status = pdevLibVirtualOS->pDevDisconnectInterruptVME(omsInterruptVector + card, (void (*)(void *)) motorIsr);
-#endif
 
     if (!RTN_SUCCESS(status))
         errPrintf(status, __FILE__, __LINE__, "Can't disconnect vector %d\n",
@@ -1126,18 +1122,15 @@ static int motor_init()
 
         Debug(9, "motor_init: devNoResponseProbe() on addr %p\n", probeAddr);
         /* Scan memory space to assure card id */
-#ifdef vxWorks
         do
         {
             status = devNoResponseProbe(OMS_ADDRS_TYPE, (unsigned int) startAddr, 1);
             startAddr += 0x2;
         } while (PROBE_SUCCESS(status) && startAddr < endAddr);
-#endif
         if (PROBE_SUCCESS(status))
         {
             struct irqdatastr *irqdata;
 
-#ifdef vxWorks
             status = devRegisterAddress(__FILE__, OMS_ADDRS_TYPE,
                                         (size_t) probeAddr, OMS_BRD_SIZE,
                                         (volatile void **) &localaddr);
@@ -1149,7 +1142,6 @@ static int motor_init()
                           "Can't register address 0x%x\n", (unsigned) probeAddr);
                 return(ERROR);
             }
-#endif
             Debug(9, "motor_init: localaddr = %p\n", localaddr);
             pmotor = (struct vmex_motor *) localaddr;
 

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -1237,7 +1237,7 @@ static int motor_init()
 
     Debug(3, "Motors initialized\n");
 
-    epicsThreadCreate((const char *) "Oms_motor", epicsThreadPriorityMedium,
+    epicsThreadCreate("Oms_motor", epicsThreadPriorityMedium,
                       epicsThreadGetStackSize(epicsThreadStackMedium),
                       (EPICSTHREADFUNC) motor_task, (void *) &targs);
 

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -926,7 +926,7 @@ static int motorIsrEnable(int card)
 #else
                                                           (void (*)(void *)) motorIsr,
 #endif
-                                                          (void *) card);
+                                                          (void *)(size_t) card);
 
         if (!RTN_SUCCESS(status))
         {

--- a/omsApp/src/drvOms.cc
+++ b/omsApp/src/drvOms.cc
@@ -278,7 +278,7 @@ static int set_status(int card, int signal)
         status.Bits.RA_PROBLEM = 1;
         motor_info->status.All = status.All;
         /* Disable board. */
-        motor_state[card] = (struct controller *) NULL;
+        motor_state[card] = NULL;
         return(rtn_state = 1); /* End move. */
     }
 
@@ -482,7 +482,7 @@ static RTN_STATUS send_mess(int card, const char *com, const char *name)
     {
         errlogPrintf(rebootmsg, card);
         /* Disable board. */
-        motor_state[card] = (struct controller *) NULL;
+        motor_state[card] = NULL;
         return(ERROR);
     }
 
@@ -490,7 +490,7 @@ static RTN_STATUS send_mess(int card, const char *com, const char *name)
     omsError(card);
 
     /* Flush receive buffer */
-    recv_mess(card, (char *) NULL, -1);
+    recv_mess(card, NULL, -1);
 
     if (name == NULL)
         strcpy(outbuf, com);
@@ -1158,16 +1158,16 @@ static int motor_init()
             irqdata->irqEnable = FALSE;
             pmotor->control = IRQ_RESET_ID;
 
-            send_mess(card_index, "EF", (char*) NULL);
-            send_mess(card_index, ERROR_CLEAR, (char*) NULL);
-            send_mess(card_index, STOP_ALL, (char*) NULL);
+            send_mess(card_index, "EF", NULL);
+            send_mess(card_index, ERROR_CLEAR, NULL);
+            send_mess(card_index, STOP_ALL, NULL);
 
-            send_mess(card_index, GET_IDENT, (char*) NULL);
+            send_mess(card_index, GET_IDENT, NULL);
 
             recv_mess(card_index, (char *) pmotorState->ident, 1);
             Debug(3, "Identification = %s\n", pmotorState->ident);
 
-            send_mess(card_index, ALL_POS, (char*) NULL);
+            send_mess(card_index, ALL_POS, NULL);
             recv_mess(card_index, axis_pos, 1);
 
             for (total_axis = 0, pos_ptr = epicsStrtok_r(axis_pos, ",", &tok_save);
@@ -1223,17 +1223,17 @@ static int motor_init()
         else
         {
             Debug(3, "motor_init: Card NOT found!\n");
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
         }
     }
 
     any_motor_in_motion = 0;
 
-    mess_queue.head = (struct mess_node *) NULL;
-    mess_queue.tail = (struct mess_node *) NULL;
+    mess_queue.head = NULL;
+    mess_queue.tail = NULL;
 
-    free_list.head = (struct mess_node *) NULL;
-    free_list.tail = (struct mess_node *) NULL;
+    free_list.head = NULL;
+    free_list.tail = NULL;
 
     Debug(3, "Motors initialized\n");
 

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -599,7 +599,7 @@ static int set_status(int card, int signal)
 
                 /* Copy device directive to buffer. */
                 strncpy(buffer, nodeptr->postmsgptr, size);
-                buffer[size] = (char) NULL;
+                buffer[size] = 0;
 
                 if (strncmp(buffer, "@PUT(", 5) != 0)
                     goto errorexit;

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -1056,7 +1056,6 @@ static void motorIsr(int card)
 
 static int motorIsrSetup(int card)
 {
-#ifdef vxWorks
     volatile struct vmex_motor *pmotor;
     long status;
     CNTRL_REG cntrlBuf;
@@ -1102,7 +1101,6 @@ static int motorIsrSetup(int card)
     cntrlBuf.Bits.intReqEna = 1;
 
     pmotor->control.cntrlReg = cntrlBuf.All;
-#endif
     return(OK);
 }
 
@@ -1158,16 +1156,13 @@ static int motor_init()
 
         Debug(9, "motor_init: devNoResponseProbe() on addr %p\n", probeAddr);
         /* Scan memory space to assure card id */
-#ifdef vxWorks
         do
         {
             status = devNoResponseProbe(OMS_ADDRS_TYPE, (unsigned int) startAddr, 2);
             startAddr += 0x100;
         } while (PROBE_SUCCESS(status) && startAddr < endAddr);
-#endif
         if (PROBE_SUCCESS(status))
         {
-#ifdef vxWorks
             status = devRegisterAddress(__FILE__, OMS_ADDRS_TYPE,
                                         (size_t) probeAddr, OMS_BRD_SIZE,
                                         (volatile void **) &localaddr);
@@ -1178,7 +1173,6 @@ static int motor_init()
                           (unsigned int) probeAddr);
                 return(ERROR);
             }
-#endif
             Debug(9, "motor_init: localaddr = %p\n", localaddr);
             pmotor = (struct vmex_motor *) localaddr;
 

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -182,7 +182,7 @@ int oms58_reboot_test = 0;
 
 
 /* --- Local data common to all OMS drivers. --- */
-static char *oms_addrs = 0x0;
+static unsigned oms_addrs = 0x0;
 static volatile unsigned omsInterruptVector = 0;
 static volatile epicsUInt8 omsInterruptLevel = OMS_INT_LEVEL;
 static volatile int max_io_tries = MAX_COUNT;
@@ -920,7 +920,7 @@ static int recv_mess(int card, char *com, int amount)
 /*****************************************************/
 RTN_STATUS
 oms58Setup(int num_cards,   /* maximum number of cards in rack */
-           void *addrs,     /* Base Address(0x0-0xb000 on 4K boundary) */
+           unsigned addrs,  /* Base Address(0x0-0xb000 on 4K boundary) */
            unsigned vector, /* noninterrupting(0), valid vectors(64-255) */
            int int_level,   /* interrupt level (1-6) */
            int scan_rate)   /* polling rate - 1-60 Hz */
@@ -941,16 +941,16 @@ oms58Setup(int num_cards,   /* maximum number of cards in rack */
         oms58_num_cards = num_cards;
 
     /* Check range and boundary(4K) on base address */
-    if (addrs > (void *) 0xF000 || ((epicsUInt64)addrs & 0xFFF))
+    if (addrs > 0xF000 || (addrs & 0xFFF))
     {
-        char format[] = "%sbase address = %p ***\n";
-        oms_addrs = (char *) OMS_NUM_ADDRS;
+        char format[] = "%sbase address = %#x ***\n";
+        oms_addrs = OMS_NUM_ADDRS;
         errlogPrintf(format, errbase, addrs);
         epicsThreadSleep(5.0);
         rtncode = ERROR;
     }
     else
-        oms_addrs = (char *) addrs;
+        oms_addrs = addrs;
 
     omsInterruptVector = vector;
     if (vector < 64 || vector > 255)
@@ -958,7 +958,7 @@ oms58Setup(int num_cards,   /* maximum number of cards in rack */
         if (vector != 0)
         {
             char format[] = "%sinterrupt vector = %d ***\n";
-            omsInterruptVector = (unsigned) OMS_INT_VECTOR;
+            omsInterruptVector = OMS_INT_VECTOR;
             errlogPrintf(format, errbase, vector);
             epicsThreadSleep(5.0);
             rtncode = ERROR;
@@ -1120,7 +1120,7 @@ static int motor_init()
     char *tok_save, *pos_ptr;
     int total_encoders = 0, total_axis = 0, total_pidcnt = 0;
     volatile void *localaddr;
-    void *probeAddr;
+    unsigned int probeAddr;
 
     tok_save = NULL;
     quantum = epicsThreadSleepQuantum();
@@ -1145,32 +1145,32 @@ static int motor_init()
 
     for (card_index = 0; card_index < oms58_num_cards; card_index++)
     {
-        epicsInt8 *startAddr;
-        epicsInt8 *endAddr;
+        unsigned int startAddr;
+        unsigned int endAddr;
 
         Debug(2, "motor_init: card %d\n", card_index);
 
         probeAddr = oms_addrs + (card_index * OMS_BRD_SIZE);
-        startAddr = (epicsInt8 *) probeAddr;
+        startAddr = probeAddr;
         endAddr = startAddr + OMS_BRD_SIZE;
 
-        Debug(9, "motor_init: devNoResponseProbe() on addr %p\n", probeAddr);
+        Debug(9, "motor_init: devNoResponseProbe() on addr %#x\n", probeAddr);
         /* Scan memory space to assure card id */
         do
         {
-            status = devNoResponseProbe(OMS_ADDRS_TYPE, (unsigned int) startAddr, 2);
+            status = devNoResponseProbe(OMS_ADDRS_TYPE, startAddr, 2);
             startAddr += 0x100;
         } while (PROBE_SUCCESS(status) && startAddr < endAddr);
         if (PROBE_SUCCESS(status))
         {
             status = devRegisterAddress(__FILE__, OMS_ADDRS_TYPE,
-                                        (size_t) probeAddr, OMS_BRD_SIZE,
-                                        (volatile void **) &localaddr);
-            Debug(9, "motor_init: devRegisterAddress() status = %d\n", (int) status);
+                                        probeAddr, OMS_BRD_SIZE,
+                                        &localaddr);
+            Debug(9, "motor_init: devRegisterAddress() status = %ld\n", status);
             if (!RTN_SUCCESS(status))
             {
-                errPrintf(status, __FILE__, __LINE__, "Can't register address 0x%x\n",
-                          (unsigned int) probeAddr);
+                errPrintf(status, __FILE__, __LINE__, "Can't register address %#x\n",
+                          probeAddr);
                 return(ERROR);
             }
             Debug(9, "motor_init: localaddr = %p\n", localaddr);
@@ -1362,12 +1362,12 @@ static const iocshFuncDef oms58FuncDef = {"oms58Setup", 5, oms58Args};
 
 static void oms58CallFunc(const iocshArgBuf* args)
 {
-	oms58Setup(args[0].ival, (void*) args[1].ival, (unsigned) args[2].ival, args[3].ival, args[4].ival);
+    oms58Setup(args[0].ival, args[1].ival, args[2].ival, args[3].ival, args[4].ival);
 }
 
 void oms58Registrar(void)
 {
-	iocshRegister(&oms58FuncDef, &oms58CallFunc);
+    iocshRegister(&oms58FuncDef, &oms58CallFunc);
 }
 
 extern "C"{

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -437,7 +437,7 @@ static int set_status(int card, int signal)
         status.Bits.RA_PROBLEM = 1;
         motor_info->status.All = status.All;
         /* Disable board. */
-        motor_state[card] = (struct controller *) NULL;
+        motor_state[card] = NULL;
         return(rtn_state = 1); /* End move. */
     }
 
@@ -687,7 +687,7 @@ static RTN_STATUS send_mess(int card, const char *com, const char *name)
     {
         errlogPrintf(rebootmsg, card);
         /* Disable board. */
-        motor_state[card] = (struct controller *) NULL;
+        motor_state[card] = NULL;
         return(ERROR);
     }
 
@@ -738,7 +738,7 @@ static RTN_STATUS send_mess(int card, const char *com, const char *name)
         {
             errlogPrintf(rebootmsg, card);
             /* Disable board. */
-            motor_state[card] = (struct controller *)NULL;
+            motor_state[card] = NULL;
             epicsThreadSleep(1.0);
             return (ERROR);
         }
@@ -1186,15 +1186,15 @@ static int motor_init()
             pmotor->control.cntrlReg = 0;   /* Disable all interrupts */
             pmotor->rebootind = 0x4321;     /* Set reboot indicator (before send_mess call). */
 
-            send_mess(card_index, "EF", (char*) NULL);
-            send_mess(card_index, ERROR_CLEAR, (char*) NULL);
-            send_mess(card_index, STOP_ALL, (char*) NULL);
+            send_mess(card_index, "EF", NULL);
+            send_mess(card_index, ERROR_CLEAR, NULL);
+            send_mess(card_index, STOP_ALL, NULL);
 
-            send_mess(card_index, GET_IDENT, (char*) NULL);
+            send_mess(card_index, GET_IDENT, NULL);
             recv_mess(card_index, (char *) pmotorState->ident, 1);
             Debug(3, "Identification = %s\n", pmotorState->ident);
 
-            send_mess(card_index, ALL_POS, (char*) NULL);
+            send_mess(card_index, ALL_POS, NULL);
             recv_mess(card_index, axis_pos, 1);
 
             for (total_axis = 0, pos_ptr = epicsStrtok_r(axis_pos, ",", &tok_save);
@@ -1285,17 +1285,17 @@ static int motor_init()
         else
         {
             Debug(3, "motor_init: Card NOT found!\n");
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
         }
     }
 
     any_motor_in_motion = 0;
 
-    mess_queue.head = (struct mess_node *) NULL;
-    mess_queue.tail = (struct mess_node *) NULL;
+    mess_queue.head = NULL;
+    mess_queue.tail = NULL;
 
-    free_list.head = (struct mess_node *) NULL;
-    free_list.tail = (struct mess_node *) NULL;
+    free_list.head = NULL;
+    free_list.tail = NULL;
 
     Debug(3, "Motors initialized\n");
 

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -1070,7 +1070,7 @@ static int motorIsrSetup(int card)
 #else
         (void (*)(void *)) motorIsr,
 #endif
-        (void *) card);
+        (void *)(size_t) card);
 
     if (!RTN_SUCCESS(status))
     {

--- a/omsApp/src/drvOms58.cc
+++ b/omsApp/src/drvOms58.cc
@@ -1318,7 +1318,7 @@ static int motor_init()
     }
 #endif
 
-    epicsThreadCreate((char *) "Oms58_motor", epicsThreadPriorityMedium,
+    epicsThreadCreate("Oms58_motor", epicsThreadPriorityMedium,
                       epicsThreadGetStackSize(epicsThreadStackMedium),
                       (EPICSTHREADFUNC) motor_task, (void *) &targs);
 

--- a/omsApp/src/drvOmsPC68.cc
+++ b/omsApp/src/drvOmsPC68.cc
@@ -853,7 +853,7 @@ static int motor_init()
     free_list.tail = NULL;
 
     Debug(3, "Motors initialized\n");
-    epicsThreadCreate((char *) "OmsPC68_motor", epicsThreadPriorityMedium,
+    epicsThreadCreate("OmsPC68_motor", epicsThreadPriorityMedium,
                       epicsThreadGetStackSize(epicsThreadStackMedium),
                       (EPICSTHREADFUNC) motor_task, (void *) &targs);
     Debug(3, "Started motor_task\n");

--- a/omsApp/src/drvOmsPC68.cc
+++ b/omsApp/src/drvOmsPC68.cc
@@ -147,7 +147,7 @@ struct driver_table OmsPC68_access =
     oms_axis
 };
 
-struct
+struct drvOmsPC68_drvet
 {
     long number;
     long (*report) (int);

--- a/omsApp/src/drvOmsPC68.cc
+++ b/omsApp/src/drvOmsPC68.cc
@@ -841,16 +841,16 @@ static int motor_init()
             }
         }
         else
-            motor_state[card_index] = (struct controller *) NULL;
+            motor_state[card_index] = NULL;
     }
 
     any_motor_in_motion = 0;
 
-    mess_queue.head = (struct mess_node *) NULL;
-    mess_queue.tail = (struct mess_node *) NULL;
+    mess_queue.head = NULL;
+    mess_queue.tail = NULL;
 
-    free_list.head = (struct mess_node *) NULL;
-    free_list.tail = (struct mess_node *) NULL;
+    free_list.head = NULL;
+    free_list.tail = NULL;
 
     Debug(3, "Motors initialized\n");
     epicsThreadCreate((char *) "OmsPC68_motor", epicsThreadPriorityMedium,
@@ -891,7 +891,7 @@ RTN_STATUS OmsPC68Setup (int num_cards, int scan_rate)
                   malloc(OmsPC68_num_cards * sizeof(struct controller *));
 
     for (itera = 0; itera < OmsPC68_num_cards; itera++)
-        motor_state[itera] = (struct controller *) NULL;
+        motor_state[itera] = NULL;
 
     return(OK);
 }

--- a/omsApp/src/drvOmsPC68.cc
+++ b/omsApp/src/drvOmsPC68.cc
@@ -685,10 +685,12 @@ static void asynCallback(void *drvPvt,asynUser *pasynUser,char *data,size_t len,
     stat = (d & 0x0000FF00) >> 8;
 
     if( stat & STAT_DONE )
+    {
         if( stat & STAT_ERROR_MSK )
             ++pcntrl->errcnt;
         else
             motor_sem.signal();
+    }
 
 //printf("drvOmsPC68:asynCallback - card %2.2d, error %d, status 0x%8.8X\n",pcntrl->card,pcntrl->errcnt,d);
 


### PR DESCRIPTION
This change allows to build the driver on non vxWorks systems (e.g. embedded Linux with VME bus support).
Several dubious casts fixed and some code cleanup.